### PR TITLE
modify output option xls to xlsx, modify output error tip csv to xlsx

### DIFF
--- a/lib/cmdline.py
+++ b/lib/cmdline.py
@@ -12,7 +12,7 @@ def cmdline():
     ip.add_argument('-i',dest="ip",type=str,help="Input your ip target(127.0.0.1 , 127.0.0.1/24 or 127.0.0.10-127.0.0.45)")
     ip.add_argument('-if',dest='ipfile',type=str,help="Input your ip's file")
     output = parser.add_argument_group('Output')
-    output.add_argument('-o',dest='output',type=str,default="html",help="Select the output format.eg(html,json,xls,default:html)")
+    output.add_argument('-o',dest='output',type=str,default="html",help="Select the output format.eg(html,json,xlsx,default:html)")
     args = parser.parse_args()
     return args
 

--- a/lib/options.py
+++ b/lib/options.py
@@ -43,7 +43,7 @@ class initoptions:
 
     def output(self):
         if self.format not in ["html", "json", "xls"]:
-            errMsg = "Ouput args is error,eg(html,json,csv default:html)"
+            errMsg = "Ouput args is error,eg(html,json,xlsx default:html)"
             logging.error(errMsg)
             exit(0)
         Save.format = self.format


### PR DESCRIPTION
修改输出格式信息提示为xlsx：
1.cmdline.py中输出格式参数提示的xls为xlsx。
2.options.py中输出格式错误提示的csv为xlsx。