### PR TITLE
self.get_faviconhash(url)方法改为self.get_faviconhash(response.url)

### DIFF
--- a/lib/req.py
+++ b/lib/req.py
@@ -60,7 +60,7 @@ class Request:
         status = response.status_code
         server = response.headers["Server"] if "Server" in response.headers else ""
         server = "" if len(server) > 50 else server
-        faviconhash = self.get_faviconhash(url)
+        faviconhash = self.get_faviconhash(response.url)
         iscdn, iplist = self.ipFactory.factory(url)
         iplist = ','.join(set(iplist))
         datas = {"url": url, "title": title, "body": html, "status": status, "Server": server, "size": size,


### PR DESCRIPTION
get_faviconhash方法是获取favicon的hash，因此个人觉得获取的favicon的url地址应该为跳转后的url地址，因此用response.url替代